### PR TITLE
Update README.md (failed to create tenant: {error=unknown_error})

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ For the application to work, please take the following steps after cloning to yo
         - Save the client
         - Go to the `Service Account Roles` tab
         - Add `admin` to the effective roles
+        - For Keycloak Version 14 go to `Scope Tab` & add `admin` to the effective roles
         - Go to the `Credentials` tab
         - Copy the secret into the `tenant` `application.yml` file
 


### PR DESCRIPTION
In keycloak running on docker image `jboss/keycloak:14.0.0` , the add tenant function throws `failed to create: {error=unknown_error}`, which I was able to resolve by adding the mentioned configuration changes in the master realm client. 

Following are the error logs.
```
2021-12-17 13:28:00.111 DEBUG  [or-http-epoll-3] [36mathPatternParserServerWebExchangeMatcher : Request 'POST /tenants' doesn't match 'null /oauth2/authorization/{registrationId}'
2021-12-17 13:28:00.114 DEBUG  [or-http-epoll-3] [36mo.s.s.w.s.u.m.OrServerWebExchangeMatcher : Trying to match using PathMatcherServerWebExchangeMatcher{pattern='/logout', method=POST}
2021-12-17 13:28:00.114 DEBUG  [or-http-epoll-3] [36mathPatternParserServerWebExchangeMatcher : Request 'POST /tenants' doesn't match 'POST /logout'
2021-12-17 13:28:00.114 DEBUG  [or-http-epoll-3] [36mo.s.s.w.s.u.m.OrServerWebExchangeMatcher : No matches found
2021-12-17 13:28:00.114 DEBUG  [or-http-epoll-3] [36ma.DelegatingReactiveAuthorizationManager : Checking authorization on '/tenants' using org.springframework.security.config.web.server.ServerHttpSecurity$AuthorizeExchangeSpec$Access$$Lambda$1196/0x00000008012870d8@230a67cb
2021-12-17 13:28:00.114 DEBUG  [or-http-epoll-3] [36mo.s.s.w.s.a.AuthorizationWebFilter       : Authorization successful
2021-12-17 13:28:00.116  INFO  [or-http-epoll-3] [36mo.i.t.controller.TenantController        : uri --> / body {realm=test102, enabled=true}
2021-12-17 13:28:00.117  INFO  [or-http-epoll-3] [36mo.i.t.TenentManagerApplication           : Request: POST http://idp:8080/auth/admin/realms/
2021-12-17 13:28:00.118 DEBUG  [or-http-epoll-3] [36mebSessionServerSecurityContextRepository : No SecurityContext found in WebSession: 'org.springframework.web.server.session.InMemoryWebSessionStore$InMemoryWebSession@c8cb1f1'
2021-12-17 13:28:00.122 DEBUG  [or-http-epoll-3] [36mr.netty.http.client.HttpClientConnect    : [id:98342350-1, L:/127.0.0.1:37882 - R:idp/127.0.0.1:8080] Handler is being applied: {uri=http://idp:8080/auth/realms/master/protocol/openid-connect/token, method=POST}
2021-12-17 13:28:00.145 DEBUG  [or-http-epoll-3] [36mr.n.http.client.HttpClientOperations     : [id:98342350-1, L:/127.0.0.1:37882 - R:idp/127.0.0.1:8080] Received response (auto-read:false) : [Cache-Control=no-store, Set-Cookie=KC_RESTART=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0; Path=/auth/realms/master/; HttpOnly, X-XSS-Protection=1; mode=block, Pragma=no-cache, X-Frame-Options=SAMEORIGIN, Referrer-Policy=no-referrer, Date=Fri, 17 Dec 2021 07:58:00 GMT, Connection=keep-alive, Strict-Transport-Security=max-age=31536000; includeSubDomains, X-Content-Type-Options=nosniff, Content-Type=application/json, content-length=1589]
2021-12-17 13:28:00.146 DEBUG  [or-http-epoll-3] [36mr.n.http.client.HttpClientOperations     : [id:98342350-1, L:/127.0.0.1:37882 - R:idp/127.0.0.1:8080] Received last HTTP packet
2021-12-17 13:28:00.147 DEBUG  [or-http-epoll-3] [36mebSessionServerSecurityContextRepository : No SecurityContext found in WebSession: 'org.springframework.web.server.session.InMemoryWebSessionStore$InMemoryWebSession@c8cb1f1'
2021-12-17 13:28:00.149 DEBUG  [or-http-epoll-3] [36mr.netty.http.client.HttpClientConnect    : [id:d3bde6fd-1, L:/127.0.0.1:37886 - R:idp/127.0.0.1:8080] Handler is being applied: {uri=http://idp:8080/auth/realms/master/protocol/openid-connect/token, method=POST}
2021-12-17 13:28:00.169 DEBUG  [or-http-epoll-3] [36mr.n.http.client.HttpClientOperations     : [id:d3bde6fd-1, L:/127.0.0.1:37886 - R:idp/127.0.0.1:8080] Received response (auto-read:false) : [Cache-Control=no-store, Set-Cookie=KC_RESTART=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0; Path=/auth/realms/master/; HttpOnly, X-XSS-Protection=1; mode=block, Pragma=no-cache, X-Frame-Options=SAMEORIGIN, Referrer-Policy=no-referrer, Date=Fri, 17 Dec 2021 07:58:00 GMT, Connection=keep-alive, Strict-Transport-Security=max-age=31536000; includeSubDomains, X-Content-Type-Options=nosniff, Content-Type=application/json, content-length=1589]
2021-12-17 13:28:00.170 DEBUG  [or-http-epoll-3] [36mr.n.http.client.HttpClientOperations     : [id:d3bde6fd-1, L:/127.0.0.1:37886 - R:idp/127.0.0.1:8080] Received last HTTP packet
2021-12-17 13:28:00.171  INFO  [or-http-epoll-3] [36mication$$EnhancerBySpringCGLIB$$c8f81799 : [id:a4e72c69] REGISTERED
2021-12-17 13:28:00.172  INFO  [or-http-epoll-3] [36mication$$EnhancerBySpringCGLIB$$c8f81799 : [id:a4e72c69] CONNECT: idp/127.0.0.1:8080
2021-12-17 13:28:00.172  INFO  [or-http-epoll-3] [36mication$$EnhancerBySpringCGLIB$$c8f81799 : [id:a4e72c69, L:/127.0.0.1:37890 - R:idp/127.0.0.1:8080] ACTIVE
2021-12-17 13:28:00.172 DEBUG  [or-http-epoll-3] [36mr.netty.http.client.HttpClientConnect    : [id:a4e72c69-1, L:/127.0.0.1:37890 - R:idp/127.0.0.1:8080] Handler is being applied: {uri=http://idp:8080/auth/admin/realms/, method=POST}
2021-12-17 13:28:00.174  INFO  [or-http-epoll-3] [36mication$$EnhancerBySpringCGLIB$$c8f81799 : [id:a4e72c69-1, L:/127.0.0.1:37890 - R:idp/127.0.0.1:8080] WRITE: 1663B POST /auth/admin/realms/ HTTP/1.1
user-agent: ReactorNetty/1.0.10
host: idp:8080
accept: */*
Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJ6cjk0SmI3X3RfWUtDT3pucVp2Si1BaWItWEVseGVzbE5nNDl2UGp1QnVnIn0.eyJleHAiOjE2Mzk3Mjc5NDAsImlhdCI6MTYzOTcyNzg4MCwianRpIjoiMjYyMDhhNzYtZGY3Ni00YjU1LWFjMDYtODdjNTVjNzcxZTBhIiwiaXNzIjoiaHR0cDovL2lkcDo4MDgwL2F1dGgvcmVhbG1zL21hc3RlciIsInN1YiI6Ijg0YjI5ZGFjLTQyOTktNDJiNi1hMmNlLTMzZTUzYmU2NWI3ZiIsInR5cCI6IkJlYXJlciIsImF6cCI6Im1hc3Rlci1yZWFsbSIsImFjciI6IjEiLCJyZXNvdXJjZV9hY2Nlc3MiOnsibWFzdGVyLXJlYWxtIjp7InJvbGVzIjpbInZpZXctaWRlbnRpdHktcHJvdmlkZXJzIiwidmlldy1yZWFsbSIsIm1hbmFnZS1pZGVudGl0eS1wcm92aWRlcnMiLCJpbXBlcnNvbmF0aW9uIiwiY3JlYXRlLWNsaWVudCIsIm1hbmFnZS11c2VycyIsInF1ZXJ5LXJlYWxtcyIsInZpZXctYXV0aG9yaXphdGlvbiIsInF1ZXJ5LWNsaWVudHMiLCJxdWVyeS11c2VycyIsIm1hbmFnZS1ldmVudHMiLCJtYW5hZ2UtcmVhbG0iLCJ2aWV3LWV2ZW50cyIsInZpZXctdXNlcnMiLCJ2aWV3LWNsaWVudHMiLCJtYW5hZ2UtYXV0aG9yaXphdGlvbiIsIm1hbmFnZS1jbGllbnRzIiwicXVlcnktZ3JvdXBzIl19fSwic2NvcGUiOiJwcm9maWxlIGVtYWlsIiwiZW1haWxfdmVyaWZpZWQiOmZhbHNlLCJjbGllbnRIb3N0IjoiMTcyLjE4LjAuMSIsImNsaWVudElkIjoibWFzdGVyLXJlYWxtIiwicHJlZmVycmVkX3VzZXJuYW1lIjoic2VydmljZS1hY2NvdW50LW1hc3Rlci1yZWFsbSIsImNsaWVudEFkZHJlc3MiOiIxNzIuMTguMC4xIn0.kceKYymvq1bxMCS7zMjoQyW5id6QBYinKT0rvs8iBYkkKjRAHGoGthBNm8Kn4KLbeOcOk-uvwK9Vg1b1sdyeGVm_5627ZdE-RZ_lCHEgqKfY4sLKRT52_2qdz-4uRm_WHNbBJy-ZgfkV7GA6w8AEU4ukFXH8-oan1Xx-jhPn3gICCUEGUY6qm26rsee89N6HzufVdOyMjnXigDwB-nfpLlWN8mjyCS5Je9oS6TtnlaTV0nteW73wAfuilbiqxgUBxL7CvCJLaOVvrMS6TBnMQfomOJARFpK5G9mr1lXqVZ0pWoQVdD_aO4h_OLZK7xq2q8RBbyaP8EWhdE-ojc4rGw
Content-Type: application/json
content-length: 34

{"realm":"test102","enabled":true}
2021-12-17 13:28:00.174  INFO  [or-http-epoll-3] [36mication$$EnhancerBySpringCGLIB$$c8f81799 : [id:a4e72c69-1, L:/127.0.0.1:37890 - R:idp/127.0.0.1:8080] FLUSH
2021-12-17 13:28:00.185  INFO  [or-http-epoll-3] [36mication$$EnhancerBySpringCGLIB$$c8f81799 : [id:a4e72c69-1, L:/127.0.0.1:37890 - R:idp/127.0.0.1:8080] READ: 353B HTTP/1.1 403 Forbidden
X-XSS-Protection: 1; mode=block
X-Frame-Options: SAMEORIGIN
Referrer-Policy: no-referrer
Date: Fri, 17 Dec 2021 07:58:00 GMT
Connection: keep-alive
Strict-Transport-Security: max-age=31536000; includeSubDomains
X-Content-Type-Options: nosniff
Content-Type: application/json
Content-Length: 25

{"error":"unknown_error"}
2021-12-17 13:28:00.185 DEBUG  [or-http-epoll-3] [36mr.n.http.client.HttpClientOperations     : [id:a4e72c69-1, L:/127.0.0.1:37890 - R:idp/127.0.0.1:8080] Received response (auto-read:false) : [X-XSS-Protection=1; mode=block, X-Frame-Options=SAMEORIGIN, Referrer-Policy=no-referrer, Date=Fri, 17 Dec 2021 07:58:00 GMT, Connection=keep-alive, Strict-Transport-Security=max-age=31536000; includeSubDomains, X-Content-Type-Options=nosniff, Content-Type=application/json, content-length=25]
2021-12-17 13:28:00.186 DEBUG  [or-http-epoll-3] [36mebSessionServerSecurityContextRepository : No SecurityContext found in WebSession: 'org.springframework.web.server.session.InMemoryWebSessionStore$InMemoryWebSession@c8cb1f1'
2021-12-17 13:28:00.186  INFO  [or-http-epoll-3] [36mreactor.Mono.FlatMap.9                   : | onSubscribe([Fuseable] MonoFlatMap.FlatMapMain)
2021-12-17 13:28:00.186  INFO  [or-http-epoll-3] [36mreactor.Mono.FlatMap.9                   : | request(unbounded)
2021-12-17 13:28:00.186 DEBUG  [or-http-epoll-3] [36mr.n.http.client.HttpClientOperations     : [id:a4e72c69-1, L:/127.0.0.1:37890 - R:idp/127.0.0.1:8080] Received last HTTP packet
2021-12-17 13:28:00.187  INFO  [or-http-epoll-3] [36mreactor.Mono.Just.10                     : | onSubscribe([Synchronous Fuseable] Operators.ScalarSubscription)
2021-12-17 13:28:00.187  INFO  [or-http-epoll-3] [36mreactor.Mono.Just.10                     : | request(unbounded)
2021-12-17 13:28:00.187  INFO  [or-http-epoll-3] [36mreactor.Mono.Just.10                     : | onNext({403 FORBIDDEN={error=unknown_error}})
2021-12-17 13:28:00.187  INFO  [or-http-epoll-3] [36mreactor.Mono.Just.10                     : | request(1)
2021-12-17 13:28:00.187  INFO  [or-http-epoll-3] [36mreactor.Mono.Just.10                     : | onComplete()
2021-12-17 13:28:00.189 ERROR  [or-http-epoll-3] [36mreactor.Mono.FlatMap.9                   : | onError(java.lang.IllegalArgumentException: failed to create: {error=unknown_error})
2021-12-17 13:28:00.193 ERROR  [or-http-epoll-3] [36mreactor.Mono.FlatMap.9                   : 

java.lang.IllegalArgumentException: failed to create: {error=unknown_error}
	at org.inventum.tenentmanager.controller.TenantController.lambda$16(TenantController.java:135) ~[classes/:na]
	at reactor.core.publisher.MonoErrorSupplied.subscribe(MonoErrorSupplied.java:55) ~[reactor-core-3.4.9.jar:3.4.9]
	at reactor.core.publisher.Mono.subscribe(Mono.java:4338) ~[reactor-core-3.4.9.jar:3.4.9]
	at reactor.core.publisher.FluxSwitchIfEmpty$SwitchIfEmptySubscriber.onComplete(FluxSwitchIfEmpty.java:82) ~[reactor-core-3.4.9.jar:3.4.9]
	at reactor.core.publisher.FluxFilterFuseable$FilterFuseableSubscriber.onComplete(FluxFilterFuseable.java:171) ~[reactor-core-3.4.9.jar:3.4.9]
	at reactor.core.publisher.FluxPeekFuseable$PeekFuseableConditionalSubscriber.onComplete(FluxPeekFuseable.java:595) ~[reactor-core-3.4.9.jar:3.4.9]
	at reactor.core.publisher.Operators$ScalarSubscription.request(Operators.java:2400) ~[reactor-core-3.4.9.jar:3.4.9]
	at reactor.core.publisher.FluxPeekFuseable$PeekFuseableConditionalSubscriber.request(FluxPeekFuseable.java:437) ~[reactor-core-3.4.9.jar:3.4.9]
	at reactor.core.publisher.FluxFilterFuseable$FilterFuseableSubscriber.request(FluxFilterFuseable.java:191) ~[reactor-core-3.4.9.jar:3.4.9]
	at reactor.core.publisher.Operators$MultiSubscriptionSubscriber.set(Operators.java:2194) ~[reactor-core-3.4.9.jar:3.4.9]
	at reactor.core.publisher.Operators$MultiSubscriptionSubscriber.onSubscribe(Operators.java:2068) ~[reactor-core-3.4.9.jar:3.4.9]
	at reactor.core.publisher.FluxFilterFuseable$FilterFuseableSubscriber.onSubscribe(FluxFilterFuseable.java:87) ~[reactor-core-3.4.9.jar:3.4.9]
	at reactor.core.publisher.FluxPeekFuseable$PeekFuseableConditionalSubscriber.onSubscribe(FluxPeekFuseable.java:471) ~[reactor-core-3.4.9.jar:3.4.9]
	at reactor.core.publisher.MonoJust.subscribe(MonoJust.java:55) ~[reactor-core-3.4.9.jar:3.4.9]
	at reactor.core.publisher.InternalMonoOperator.subscribe(InternalMonoOperator.java:64) ~[reactor-core-3.4.9.jar:3.4.9]
	at reactor.core.publisher.MonoFlatMap$FlatMapMain.onNext(MonoFlatMap.java:157) ~[reactor-core-3.4.9.jar:3.4.9]
	at reactor.core.publisher.FluxSwitchIfEmpty$SwitchIfEmptySubscriber.onNext(FluxSwitchIfEmpty.java:74) ~[reactor-core-3.4.9.jar:3.4.9]
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onNext(FluxOnAssembly.java:388) ~[reactor-core-3.4.9.jar:3.4.9]
	at reactor.core.publisher.Operators$MonoSubscriber.complete(Operators.java:1816) ~[reactor-core-3.4.9.jar:3.4.9]
	at reactor.core.publisher.MonoFlatMap$FlatMapMain.onNext(MonoFlatMap.java:151) ~[reactor-core-3.4.9.jar:3.4.9]
	at reactor.core.publisher.FluxContextWrite$ContextWriteSubscriber.onNext(FluxContextWrite.java:107) ~[reactor-core-3.4.9.jar:3.4.9]
	at reactor.core.publisher.FluxMapFuseable$MapFuseableConditionalSubscriber.onNext(FluxMapFuseable.java:295) ~[reactor-core-3.4.9.jar:3.4.9]
	at reactor.core.publisher.FluxFilterFuseable$FilterFuseableConditionalSubscriber.onNext(FluxFilterFuseable.java:337) ~[reactor-core-3.4.9.jar:3.4.9]
	at reactor.core.publisher.Operators$MonoSubscriber.complete(Operators.java:1816) ~[reactor-core-3.4.9.jar:3.4.9]
	at reactor.core.publisher.MonoCollect$CollectSubscriber.onComplete(MonoCollect.java:159) ~[reactor-core-3.4.9.jar:3.4.9]
	at reactor.core.publisher.FluxMap$MapSubscriber.onComplete(FluxMap.java:142) ~[reactor-core-3.4.9.jar:3.4.9]
	at reactor.core.publisher.FluxPeek$PeekSubscriber.onComplete(FluxPeek.java:260) ~[reactor-core-3.4.9.jar:3.4.9]
	at reactor.core.publisher.FluxMap$MapSubscriber.onComplete(FluxMap.java:142) ~[reactor-core-3.4.9.jar:3.4.9]
	at reactor.netty.channel.FluxReceive.onInboundComplete(FluxReceive.java:400) ~[reactor-netty-core-1.0.10.jar:1.0.10]
	at reactor.netty.channel.ChannelOperations.onInboundComplete(ChannelOperations.java:419) ~[reactor-netty-core-1.0.10.jar:1.0.10]
	at reactor.netty.channel.ChannelOperations.terminate(ChannelOperations.java:473) ~[reactor-netty-core-1.0.10.jar:1.0.10]
	at reactor.netty.http.client.HttpClientOperations.onInboundNext(HttpClientOperations.java:684) ~[reactor-netty-http-1.0.10.jar:1.0.10]
	at reactor.netty.channel.ChannelOperationsHandler.channelRead(ChannelOperationsHandler.java:93) ~[reactor-netty-core-1.0.10.jar:1.0.10]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-transport-4.1.67.Final.jar:4.1.67.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[netty-transport-4.1.67.Final.jar:4.1.67.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[netty-transport-4.1.67.Final.jar:4.1.67.Final]
	at io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireChannelRead(CombinedChannelDuplexHandler.java:436) ~[netty-transport-4.1.67.Final.jar:4.1.67.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:324) ~[netty-codec-4.1.67.Final.jar:4.1.67.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296) ~[netty-codec-4.1.67.Final.jar:4.1.67.Final]
	at io.netty.channel.CombinedChannelDuplexHandler.channelRead(CombinedChannelDuplexHandler.java:251) ~[netty-transport-4.1.67.Final.jar:4.1.67.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-transport-4.1.67.Final.jar:4.1.67.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[netty-transport-4.1.67.Final.jar:4.1.67.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[netty-transport-4.1.67.Final.jar:4.1.67.Final]
	at io.netty.handler.logging.LoggingHandler.channelRead(LoggingHandler.java:280) ~[netty-handler-4.1.67.Final.jar:4.1.67.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-transport-4.1.67.Final.jar:4.1.67.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[netty-transport-4.1.67.Final.jar:4.1.67.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[netty-transport-4.1.67.Final.jar:4.1.67.Final]
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410) ~[netty-transport-4.1.67.Final.jar:4.1.67.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-transport-4.1.67.Final.jar:4.1.67.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[netty-transport-4.1.67.Final.jar:4.1.67.Final]
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919) ~[netty-transport-4.1.67.Final.jar:4.1.67.Final]
	at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:795) ~[netty-transport-native-epoll-4.1.67.Final-linux-x86_64.jar:4.1.67.Final]
	at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:480) ~[netty-transport-native-epoll-4.1.67.Final-linux-x86_64.jar:4.1.67.Final]
	at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:378) ~[netty-transport-native-epoll-4.1.67.Final-linux-x86_64.jar:4.1.67.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986) ~[netty-common-4.1.67.Final.jar:4.1.67.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[netty-common-4.1.67.Final.jar:4.1.67.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[netty-common-4.1.67.Final.jar:4.1.67.Final]
	at java.base/java.lang.Thread.run(Thread.java:831) ~[na:na]

2021-12-17 13:28:00.210 ERROR  [or-http-epoll-3] [36ma.w.r.e.AbstractErrorWebExceptionHandler : [51c44109-1]  500 Server Error for HTTP POST "/tenants?useJwt=false"

java.lang.IllegalArgumentException: failed to create: {error=unknown_error}
	at org.inventum.tenentmanager.controller.TenantController.lambda$16(TenantController.java:135) ~[classes/:na]
	Suppressed: reactor.core.publisher.FluxOnAssembly$OnAssemblyException: 
Assembly trace from producer [reactor.core.publisher.MonoFlatMap] :
	reactor.core.publisher.Mono.checkpoint(Mono.java:2120)
	org.inventum.tenentmanager.controller.TenantController.add(TenantController.java:94)
Error has been observed at the following site(s):
	|_ Mono.checkpoint ⇢ at org.inventum.tenentmanager.controller.TenantController.add(TenantController.java:94)
	|_ Mono.checkpoint ⇢ at org.inventum.tenentmanager.controller.TenantController.add(TenantController.java:98)
	|_      checkpoint ⇢ Handler org.inventum.tenentmanager.controller.TenantController#add(boolean, Tenant) [DispatcherHandler]
	|_      checkpoint ⇢ springfox.boot.starter.autoconfigure.SwaggerUiWebFluxConfiguration$CustomWebFilter [DefaultWebFilterChain]
	|_      checkpoint ⇢ org.springframework.security.web.server.authorization.AuthorizationWebFilter [DefaultWebFilterChain]
	|_      checkpoint ⇢ org.springframework.security.web.server.authorization.ExceptionTranslationWebFilter [DefaultWebFilterChain]
	|_      checkpoint ⇢ org.springframework.security.web.server.authentication.logout.LogoutWebFilter [DefaultWebFilterChain]
	|_      checkpoint ⇢ org.springframework.security.web.server.savedrequest.ServerRequestCacheWebFilter [DefaultWebFilterChain]
	|_      checkpoint ⇢ org.springframework.security.web.server.context.SecurityContextServerWebExchangeWebFilter [DefaultWebFilterChain]
	|_      checkpoint ⇢ org.springframework.security.oauth2.client.web.server.OAuth2AuthorizationCodeGrantWebFilter [DefaultWebFilterChain]
	|_      checkpoint ⇢ org.springframework.security.oauth2.client.web.server.OAuth2AuthorizationRequestRedirectWebFilter [DefaultWebFilterChain]
	|_      checkpoint ⇢ org.springframework.security.web.server.context.ReactorContextWebFilter [DefaultWebFilterChain]
	|_      checkpoint ⇢ org.springframework.security.web.server.header.HttpHeaderWriterWebFilter [DefaultWebFilterChain]
	|_      checkpoint ⇢ org.springframework.security.config.web.server.ServerHttpSecurity$ServerWebExchangeReactorContextWebFilter [DefaultWebFilterChain]
	|_      checkpoint ⇢ org.springframework.security.web.server.WebFilterChainProxy [DefaultWebFilterChain]
	|_      checkpoint ⇢ org.springframework.boot.actuate.metrics.web.reactive.server.MetricsWebFilter [DefaultWebFilterChain]
	|_      checkpoint ⇢ HTTP POST "/tenants?useJwt=false" [ExceptionHandlingWebHandler]
Stack trace:
		at org.inventum.tenentmanager.controller.TenantController.lambda$16(TenantController.java:135) ~[classes/:na]
		at reactor.core.publisher.MonoErrorSupplied.subscribe(MonoErrorSupplied.java:55) ~[reactor-core-3.4.9.jar:3.4.9]
		at reactor.core.publisher.Mono.subscribe(Mono.java:4338) ~[reactor-core-3.4.9.jar:3.4.9]
		at reactor.core.publisher.FluxSwitchIfEmpty$SwitchIfEmptySubscriber.onComplete(FluxSwitchIfEmpty.java:82) ~[reactor-core-3.4.9.jar:3.4.9]
		at reactor.core.publisher.FluxFilterFuseable$FilterFuseableSubscriber.onComplete(FluxFilterFuseable.java:171) ~[reactor-core-3.4.9.jar:3.4.9]
		at reactor.core.publisher.FluxPeekFuseable$PeekFuseableConditionalSubscriber.onComplete(FluxPeekFuseable.java:595) ~[reactor-core-3.4.9.jar:3.4.9]
		at reactor.core.publisher.Operators$ScalarSubscription.request(Operators.java:2400) ~[reactor-core-3.4.9.jar:3.4.9]
		at reactor.core.publisher.FluxPeekFuseable$PeekFuseableConditionalSubscriber.request(FluxPeekFuseable.java:437) ~[reactor-core-3.4.9.jar:3.4.9]
		at reactor.core.publisher.FluxFilterFuseable$FilterFuseableSubscriber.request(FluxFilterFuseable.java:191) ~[reactor-core-3.4.9.jar:3.4.9]
		at reactor.core.publisher.Operators$MultiSubscriptionSubscriber.set(Operators.java:2194) ~[reactor-core-3.4.9.jar:3.4.9]
		at reactor.core.publisher.Operators$MultiSubscriptionSubscriber.onSubscribe(Operators.java:2068) ~[reactor-core-3.4.9.jar:3.4.9]
		at reactor.core.publisher.FluxFilterFuseable$FilterFuseableSubscriber.onSubscribe(FluxFilterFuseable.java:87) ~[reactor-core-3.4.9.jar:3.4.9]
		at reactor.core.publisher.FluxPeekFuseable$PeekFuseableConditionalSubscriber.onSubscribe(FluxPeekFuseable.java:471) ~[reactor-core-3.4.9.jar:3.4.9]
		at reactor.core.publisher.MonoJust.subscribe(MonoJust.java:55) ~[reactor-core-3.4.9.jar:3.4.9]
		at reactor.core.publisher.InternalMonoOperator.subscribe(InternalMonoOperator.java:64) ~[reactor-core-3.4.9.jar:3.4.9]
		at reactor.core.publisher.MonoFlatMap$FlatMapMain.onNext(MonoFlatMap.java:157) ~[reactor-core-3.4.9.jar:3.4.9]
		at reactor.core.publisher.FluxSwitchIfEmpty$SwitchIfEmptySubscriber.onNext(FluxSwitchIfEmpty.java:74) ~[reactor-core-3.4.9.jar:3.4.9]
		at reactor.core.publisher.Operators$MonoSubscriber.complete(Operators.java:1816) ~[reactor-core-3.4.9.jar:3.4.9]
		at reactor.core.publisher.MonoFlatMap$FlatMapMain.onNext(MonoFlatMap.java:151) ~[reactor-core-3.4.9.jar:3.4.9]
		at reactor.core.publisher.FluxContextWrite$ContextWriteSubscriber.onNext(FluxContextWrite.java:107) ~[reactor-core-3.4.9.jar:3.4.9]
		at reactor.core.publisher.FluxMapFuseable$MapFuseableConditionalSubscriber.onNext(FluxMapFuseable.java:295) ~[reactor-core-3.4.9.jar:3.4.9]
		at reactor.core.publisher.FluxFilterFuseable$FilterFuseableConditionalSubscriber.onNext(FluxFilterFuseable.java:337) ~[reactor-core-3.4.9.jar:3.4.9]
		at reactor.core.publisher.Operators$MonoSubscriber.complete(Operators.java:1816) ~[reactor-core-3.4.9.jar:3.4.9]
		at reactor.core.publisher.MonoCollect$CollectSubscriber.onComplete(MonoCollect.java:159) ~[reactor-core-3.4.9.jar:3.4.9]
		at reactor.core.publisher.FluxMap$MapSubscriber.onComplete(FluxMap.java:142) ~[reactor-core-3.4.9.jar:3.4.9]
		at reactor.core.publisher.FluxPeek$PeekSubscriber.onComplete(FluxPeek.java:260) ~[reactor-core-3.4.9.jar:3.4.9]
		at reactor.core.publisher.FluxMap$MapSubscriber.onComplete(FluxMap.java:142) ~[reactor-core-3.4.9.jar:3.4.9]
		at reactor.netty.channel.FluxReceive.onInboundComplete(FluxReceive.java:400) ~[reactor-netty-core-1.0.10.jar:1.0.10]
		at reactor.netty.channel.ChannelOperations.onInboundComplete(ChannelOperations.java:419) ~[reactor-netty-core-1.0.10.jar:1.0.10]
		at reactor.netty.channel.ChannelOperations.terminate(ChannelOperations.java:473) ~[reactor-netty-core-1.0.10.jar:1.0.10]
		at reactor.netty.http.client.HttpClientOperations.onInboundNext(HttpClientOperations.java:684) ~[reactor-netty-http-1.0.10.jar:1.0.10]
		at reactor.netty.channel.ChannelOperationsHandler.channelRead(ChannelOperationsHandler.java:93) ~[reactor-netty-core-1.0.10.jar:1.0.10]
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-transport-4.1.67.Final.jar:4.1.67.Final]
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[netty-transport-4.1.67.Final.jar:4.1.67.Final]
		at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[netty-transport-4.1.67.Final.jar:4.1.67.Final]
		at io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireChannelRead(CombinedChannelDuplexHandler.java:436) ~[netty-transport-4.1.67.Final.jar:4.1.67.Final]
		at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:324) ~[netty-codec-4.1.67.Final.jar:4.1.67.Final]
		at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296) ~[netty-codec-4.1.67.Final.jar:4.1.67.Final]
		at io.netty.channel.CombinedChannelDuplexHandler.channelRead(CombinedChannelDuplexHandler.java:251) ~[netty-transport-4.1.67.Final.jar:4.1.67.Final]
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-transport-4.1.67.Final.jar:4.1.67.Final]
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[netty-transport-4.1.67.Final.jar:4.1.67.Final]
		at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[netty-transport-4.1.67.Final.jar:4.1.67.Final]
		at io.netty.handler.logging.LoggingHandler.channelRead(LoggingHandler.java:280) ~[netty-handler-4.1.67.Final.jar:4.1.67.Final]
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-transport-4.1.67.Final.jar:4.1.67.Final]
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[netty-transport-4.1.67.Final.jar:4.1.67.Final]
		at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[netty-transport-4.1.67.Final.jar:4.1.67.Final]
		at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410) ~[netty-transport-4.1.67.Final.jar:4.1.67.Final]
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-transport-4.1.67.Final.jar:4.1.67.Final]
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[netty-transport-4.1.67.Final.jar:4.1.67.Final]
		at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919) ~[netty-transport-4.1.67.Final.jar:4.1.67.Final]
		at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:795) ~[netty-transport-native-epoll-4.1.67.Final-linux-x86_64.jar:4.1.67.Final]
		at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:480) ~[netty-transport-native-epoll-4.1.67.Final-linux-x86_64.jar:4.1.67.Final]
		at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:378) ~[netty-transport-native-epoll-4.1.67.Final-linux-x86_64.jar:4.1.67.Final]
		at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986) ~[netty-common-4.1.67.Final.jar:4.1.67.Final]
		at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[netty-common-4.1.67.Final.jar:4.1.67.Final]
		at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[netty-common-4.1.67.Final.jar:4.1.67.Final]
		at java.base/java.lang.Thread.run(Thread.java:831) ~[na:na]

2021-12-17 13:28:00.217  INFO  [or-http-epoll-3] [36mication$$EnhancerBySpringCGLIB$$c8f81799 : [id:a4e72c69, L:/127.0.0.1:37890 - R:idp/127.0.0.1:8080] READ COMPLETE
```